### PR TITLE
Some additional Glitches and Cleanups

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -4,6 +4,7 @@
       "numWorkersPerCPU": 0.0,
       "numWorkers": 1,
       "resultGoodForSeconds": 0.5,
+      "faceBoxSizeAdjustment": 1.2,
       "dlibFaceDetector": "data/dlib-models/mmod_human_face_detector.dat"
     },
     "FaceTracker": {

--- a/data/config.json
+++ b/data/config.json
@@ -11,13 +11,13 @@
       "numWorkersPerCPU": 0.1375,
       "numWorkers": 0,
       "dlibFaceLandmarks": "data/dlib-models/shape_predictor_68_face_landmarks.dat",
-      "poseSmoothingOverSeconds": 0.5,
+      "poseSmoothingOverSeconds": 0.25,
       "poseSmoothingExponent": 3,
       "poseRotationLowRejectionThreshold": 2.0,
-      "poseTranslationLowRejectionThreshold": 7.0,
       "poseRotationLowRejectionThresholdInternal": 1.25,
-      "poseTranslationLowRejectionThresholdInternal": 3.0,
       "poseRotationHighRejectionThreshold": 13,
+      "poseTranslationLowRejectionThreshold": 7.0,
+      "poseTranslationLowRejectionThresholdInternal": 3.0,
       "poseTranslationHighRejectionThreshold": 210,
       "poseTranslationMaxX": 125,
       "poseTranslationMinX": -125,
@@ -62,7 +62,7 @@
     },
     "MarkerTracker": {
       "pointSmoothingOverSeconds": 0.25,
-      "pointSmoothingExponent": 1.25,
+      "pointSmoothingExponent": 2.0,
       "pointMotionLowRejectionThreshold": 1.25,
       "pointMotionHighRejectionThreshold": 30.0,
       "markerRejectionResetAfterSeconds": 0.1
@@ -142,7 +142,7 @@
     "PreviewHUD": {
       "numWorkersPerCPU": 0.5,
       "numWorkers": 0,
-      "initialPreviewDisplayDensity": 4,
+      "initialPreviewDisplayDensity": 1,
       "previewRatio": 1.25,
       "previewWidthPercentage": 0.2,
       "previewCenterHeightPercentage": 0.2

--- a/data/config.json
+++ b/data/config.json
@@ -11,6 +11,7 @@
       "numWorkersPerCPU": 0.1375,
       "numWorkers": 0,
       "dlibFaceLandmarks": "data/dlib-models/shape_predictor_68_face_landmarks.dat",
+      "useFullSizedFrameForLandmarkDetection": true,
       "poseSmoothingOverSeconds": 0.25,
       "poseSmoothingExponent": 3,
       "poseRotationLowRejectionThreshold": 2.0,

--- a/src/FFmpegDriver.hpp
+++ b/src/FFmpegDriver.hpp
@@ -3,6 +3,7 @@
 #include "Logger.hpp"
 #include "Utilities.hpp"
 #include "FrameServer.hpp"
+#include "WorkerPool.hpp"
 
 #include <string>
 #include <list>
@@ -23,6 +24,7 @@ namespace YerFace {
 #define YERFACE_INITIAL_VIDEO_BACKING_FRAMES 60
 
 class FrameServer;
+class WorkerPool;
 
 enum FFmpegDriverOutAudioChannelMap {
 	CHANNELMAP_NONE = 0,
@@ -108,6 +110,7 @@ public:
 	FFmpegDriver(Status *myStatus, FrameServer *myFrameServer, bool myLowLatency, bool myListAllAvailableOptions);
 	~FFmpegDriver();
 	void openInputMedia(string inFile, enum AVMediaType type, String inFormat, String inSize, String inChannels, String inRate, String inCodec, String outAudioChannelMap, bool tryAudio);
+	void setVideoCaptureWorkerPool(WorkerPool *workerPool);
 	void rollDemuxerThreads(void);
 	bool getIsAudioInputPresent(void);
 	bool getIsVideoFrameBufferEmpty(void);
@@ -141,6 +144,7 @@ private:
 	Status *status;
 	FrameServer *frameServer;
 	bool lowLatency;
+	WorkerPool *videoCaptureWorkerPool;
 
 	Logger *logger;
 

--- a/src/FaceDetector.hpp
+++ b/src/FaceDetector.hpp
@@ -73,7 +73,7 @@ private:
 	static bool assignmentWorkerHandler(WorkerPoolWorker *worker);
 
 	string faceDetectionModelFileName;
-	double resultGoodForSeconds;
+	double resultGoodForSeconds, faceBoxSizeAdjustment;
 
 	bool usingDNNFaceDetection;
 

--- a/src/FaceTracker.hpp
+++ b/src/FaceTracker.hpp
@@ -168,6 +168,7 @@ private:
 	static bool assignmentWorkerHandler(WorkerPoolWorker *worker);
 
 	string featureDetectionModelFileName, faceDetectionModelFileName;
+	bool useFullSizedFrameForLandmarkDetection;
 	Status *status;
 	SDLDriver *sdlDriver;
 	FrameServer *frameServer;

--- a/src/MarkerTracker.cpp
+++ b/src/MarkerTracker.cpp
@@ -246,6 +246,7 @@ void MarkerTracker::calculate3dMarkerPoint(FrameNumber frameNumber, MarkerPoint 
 	FacialPose facialPose = faceTracker->getFacialPose(frameNumber);
 	FacialCameraModel cameraModel = faceTracker->getFacialCameraModel();
 	if(!facialPose.set || !cameraModel.set) {
+		markerPoint->set = false;
 		return;
 	}
 	FacialPlane facialPlane = faceTracker->getCalculatedFacialPlaneForWorkingFacialPose(frameNumber, markerType);

--- a/src/OutputDriver.cpp
+++ b/src/OutputDriver.cpp
@@ -204,7 +204,6 @@ void OutputDriver::setEventLogger(EventLogger *myEventLogger) {
 	eventLogger->registerEventType(basisEvent);
 }
 
-// FIXME - event lifecycle
 void OutputDriver::handleNewBasisEvent(FrameNumber frameNumber) {
 	logger->verbose("Got a Basis Flag event for Frame #%lu. Handling...", frameNumber);
 	YerFace_MutexLock(workerMutex);


### PR DESCRIPTION
This pull request:
- Addresses a common cause of facial landmarks jumping off of their mark (especially the jawline) by increasing the size of the facial detection rectangle by some adjustable percentage. (Sometimes the facial detection box crops the side of the face, causing the facial landmark predictor to screw up.)
- Cleans up and improves the pose and marker smoothing code, increasing responsiveness without (hopefully) introducing any noticeable jitter.
- Solves a number of FIXME notices in the code, including: exposing the option of performing facial landmark detection using a smaller frame size and correcting bad timing behavior in the main video capture loop.